### PR TITLE
chore(strict): set strict types on all php classes

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -193,7 +193,7 @@
   <component name="PhpUnit">
     <phpunit_settings>
       <phpunit_by_interpreter interpreter_id="e823741b-32a6-4a94-886b-b30957e438e5" configuration_file_path="/var/www/html/phpunit.xml.dist" custom_loader_path="/var/www/html/vendor/autoload.php" phpunit_phar_path="" use_configuration_file="true" />
-      <PhpUnitSettings configuration_file_path="$PROJECT_DIR$/phpunit.xml.dist" custom_loader_path="$PROJECT_DIR$/vendor/autoload.php" use_configuration_file="true" />
+      <PhpUnitSettings configuration_file_path="$PROJECT_DIR$/phpunit.xml.dist" custom_loader_path="$PROJECT_DIR$/vendor/autoload.php" phpunit_phar_path="" use_configuration_file="true" />
     </phpunit_settings>
   </component>
   <component name="Psalm">

--- a/src/Controller/CreateSubcontractorController.php
+++ b/src/Controller/CreateSubcontractorController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
 use App\Entity\Subcontractor;

--- a/src/Core/FinalCost.php
+++ b/src/Core/FinalCost.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Core;
 
 use App\Entity\Subcontractor;

--- a/src/Entity/Subcontractor.php
+++ b/src/Entity/Subcontractor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Entity;
 
 use App\Repository\SubcontractorRepository;

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;

--- a/src/Model/CreateSubcontractor.php
+++ b/src/Model/CreateSubcontractor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model;
 
 final class CreateSubcontractor

--- a/src/Repository/SubcontractorRepository.php
+++ b/src/Repository/SubcontractorRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\Subcontractor;

--- a/src/Services/RequestHandler.php
+++ b/src/Services/RequestHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services;
 
 use Symfony\Component\HttpFoundation\Request;

--- a/tests/Functional/BaseWebTestCase.php
+++ b/tests/Functional/BaseWebTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;

--- a/tests/Functional/CreateSubcontractorTest.php
+++ b/tests/Functional/CreateSubcontractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Functional;
 
 use App\Entity\Subcontractor;

--- a/tests/Functional/PatchSubcontractorTest.php
+++ b/tests/Functional/PatchSubcontractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Functional;
 
 use App\Entity\Subcontractor;

--- a/tests/Unit/FinalCostTest.php
+++ b/tests/Unit/FinalCostTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Unit;
 
 use App\Core\FinalCost;


### PR DESCRIPTION
We use the strict_types=1 in all our PHP classes, automatically added by code quality tools in our main repo, but here you'll need to add it manually. Unsure what it means? [Here's a StackOverflow link that explains it](https://stackoverflow.com/questions/48723637/what-do-strict-types-do-in-php)