### PR TITLE
fix(tasks): Remove task three

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ and you'll be up and running in less than 10 minutes.
 2. Follow the [Setup guide](/doc/setup.md) to get up and running
 3. Take on the [Challenge](/doc/task.md)
 
+
+---
+
 ## About us
 
 [ProcurePro](https://procurepro.co) is on a mission to __transform construction procurement__, helping

--- a/doc/task.md
+++ b/doc/task.md
@@ -59,7 +59,20 @@ In order to complete this challenge, we have provided you with the following:
 
 There are two tasks for you to complete:
 
-### 1. Create an endpoint to PATCH a Subcontractor
+### 1. Implement the `App\Core\FinalCost` core function
+
+As detailed above, the __final cost__ is calculated with:
+
+```
+final cost = price - discount + adjustment + unlet cost
+```
+
+This calculation is simpler than it appears since each property is nullable. Be sure to write solid tests for this one,
+you would hate someone to come along in a few months, change a `+` to a `-` and break the entire application 😱.
+
+Once this is complete, the `ListSubcontractors` endpoint should work successfully.
+
+### 2. Create an endpoint to PATCH a Subcontractor
 
 Create a controller for a `PATCH /subcontractors/{id}` endpoint. It should take a subcontractor id as a path parameter,
 and take the following request body as JSON where every property is __optional__ (i.e. a client should be able
@@ -79,16 +92,3 @@ Note that:
 
 - you already have one failing test for this endpoint (but more may be required)
 - once a property on a Subcontractor has been set once, it should not be possible to set it back to `null`
-
-### 2. Implement the `App\Core\FinalCost` core function
-
-As detailed above, the __final cost__ is calculated with:
-
-```
-final cost = price - discount + adjustment + unlet cost
-```
-
-This calculation is simpler than it appears since each property is nullable. Be sure to write solid tests for this one,
-you would hate someone to come along in a few months, change a `+` to a `-` and break the entire application 😱.
-
-Once this is complete, the `ListSubcontractors` endpoint should work successfully.

--- a/doc/task.md
+++ b/doc/task.md
@@ -43,6 +43,12 @@ In order to complete this challenge, we have provided you with the following:
     - An example of how we
         - make an HTTP request during a test; and
         - assert on the state of the database afterwards
+- An endpoint and functional test for listing al subcontractors 
+    ([ListSubcontractorsController](/src/Controller/ListSubcontractorsController.php))
+  - Demonstration of:
+    - how to load entities from the database; and
+    - using response models
+  - This endpoint currently returns a 500 `FinalCost` is not yet implemented
 - A failing functional test for a missing patch subcontractor
   endpoint ([PatchSubcontractorTest](/tests/Functional/PatchSubcontractorTest.php))
     - Showing how to load database fixtures in a test
@@ -51,7 +57,7 @@ In order to complete this challenge, we have provided you with the following:
 - A failing unit test for the FinalCost core function ([FinalCostTest](/tests/Unit/FinalCostTest.php))
     - Showing how to create a unit test
 
-There are three separate tasks for you to complete:
+There are two tasks for you to complete:
 
 ### 1. Create an endpoint to PATCH a Subcontractor
 
@@ -85,21 +91,4 @@ final cost = price - discount + adjustment + unlet cost
 This calculation is simpler than it appears since each property is nullable. Be sure to write solid tests for this one,
 you would hate someone to come along in a few months, change a `+` to a `-` and break the entire application 😱.
 
-### 3. Create an endpoint to list all Subcontractors
-
-create a controller for `GET /subcontractors`. It should fetch all the Subcontractors from the database and return JSON
-data in the following format:
-
-```
-{
-  name: string
-  price: integer | null
-  discount: integer | null
-  adjustment: integer | null
-  unletCost: integer | null
-  finalCost: integer
-}
-```
-
-Note the addition of `finalCost` to the other Subcontractor properties, which can calculate with the core function from
-step 2 😉.
+Once this is complete, the `ListSubcontractors` endpoint should work successfully.

--- a/fixtures/main.yaml
+++ b/fixtures/main.yaml
@@ -14,3 +14,9 @@ App\Entity\Subcontractor:
             - <catchPhrase()>
         price: <numberBetween(10_000_00, 10_000_000_00)>
         unletCost: <numberBetween(1_000_00, 10_000_00)>
+    subcontractor_known:
+        __construct:
+            - Concrete Bros.
+        price: 50_000_00
+        discount: 5_000_00
+        unletCost: 500_00

--- a/src/Controller/ListSubcontractorsController.php
+++ b/src/Controller/ListSubcontractorsController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\Subcontractor;
+use App\Model\SubcontractorResponse;
+use App\Repository\SubcontractorRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class ListSubcontractorsController extends AbstractController
+{
+    public function __construct(
+        private readonly SubcontractorRepository $subcontractorRepository,
+    ) {
+    }
+
+    #[Route('/subcontractors', methods: ['GET'])]
+    public function __invoke(Request $request): Response
+    {
+        $subcontractors = $this->subcontractorRepository->findAll();
+
+        $response = \array_map(
+            fn(Subcontractor $sub) => new SubcontractorResponse($sub),
+            $subcontractors,
+        );
+
+        return $this->json($response, 200);
+    }
+}

--- a/src/Entity/Subcontractor.php
+++ b/src/Entity/Subcontractor.php
@@ -13,7 +13,7 @@ class Subcontractor
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
-    private ?int $id = null;
+    private int $id;
 
     #[ORM\Column(length: 255)]
     private string $name;
@@ -35,12 +35,12 @@ class Subcontractor
         $this->name = $name;
     }
 
-    public function getId(): ?int
+    public function getId(): int
     {
         return $this->id;
     }
 
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/Entity/Subcontractor.php
+++ b/src/Entity/Subcontractor.php
@@ -13,7 +13,7 @@ class Subcontractor
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
-    private int $id;
+    private ?int $id = null;
 
     #[ORM\Column(length: 255)]
     private string $name;
@@ -35,7 +35,7 @@ class Subcontractor
         $this->name = $name;
     }
 
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/src/Model/SubcontractorResponse.php
+++ b/src/Model/SubcontractorResponse.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use App\Core\FinalCost;
+use App\Entity\Subcontractor;
+
+final class SubcontractorResponse
+{
+    public readonly int $id;
+
+    public readonly string $name;
+
+    public readonly ?int $price;
+
+    public readonly ?int $discount;
+
+    public readonly ?int $adjustment;
+
+    public readonly ?int $unletCost;
+
+    public readonly ?int $finalCost;
+
+    public function __construct(Subcontractor $subcontractor)
+    {
+        $this->id         = $subcontractor->getId();
+        $this->name       = $subcontractor->getName();
+        $this->price      = $subcontractor->getPrice();
+        $this->discount   = $subcontractor->getDiscount();
+        $this->adjustment = $subcontractor->getAdjustment();
+        $this->unletCost  = $subcontractor->getUnletCost();
+        $this->finalCost  = FinalCost::calculate($subcontractor);
+    }
+}

--- a/src/Model/SubcontractorResponse.php
+++ b/src/Model/SubcontractorResponse.php
@@ -9,7 +9,7 @@ use App\Entity\Subcontractor;
 
 final class SubcontractorResponse
 {
-    public readonly int $id;
+    public readonly ?int $id;
 
     public readonly string $name;
 

--- a/src/Utility/ArrayUtility.php
+++ b/src/Utility/ArrayUtility.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace App\Utility;
 
+/**
+ * A helper class to make php *_array functions work more intuitively, and to provide functions not available in the
+ * PHP core. This class is intentionally untested as it will be covered by everywhere that uses it anyway.
+ */
 final class ArrayUtility
 {
     private function __construct()

--- a/src/Utility/ArrayUtility.php
+++ b/src/Utility/ArrayUtility.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Utility;
+
+final class ArrayUtility
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @template     T
+     *
+     * @psalm-param  T[]             $haystack
+     * @psalm-param callable(T):bool $function
+     *
+     * @psalm-return list<T>
+     */
+    public static function arrayFilter(array $haystack, callable $function): array
+    {
+        return \array_values(\array_filter($haystack, $function));
+    }
+
+    /**
+     * @template     T
+     *
+     * @psalm-param  T[]             $haystack
+     * @psalm-param callable(T):bool $function
+     *
+     * @psalm-return null|T
+     */
+    public static function arrayFind(array $haystack, callable $function): mixed
+    {
+        $filtered = self::arrayFilter($haystack, $function);
+        if (0 === \count($filtered)) {
+            return null;
+        }
+
+        return $filtered[0];
+    }
+}

--- a/tests/Functional/BaseWebTestCase.php
+++ b/tests/Functional/BaseWebTestCase.php
@@ -20,10 +20,15 @@ abstract class BaseWebTestCase extends WebTestCase
         $this->client = static::createClient();
     }
 
+    protected function doGetRequest(string $uri): Response
+    {
+        return $this->jsonRequest('GET', $uri, []);
+    }
+
     /**
      * @param mixed[] $payload
      */
-    protected function postRequest(string $uri, array $payload): Response
+    protected function doPostRequest(string $uri, array $payload): Response
     {
         return $this->jsonRequest('POST', $uri, $payload);
     }
@@ -31,7 +36,7 @@ abstract class BaseWebTestCase extends WebTestCase
     /**
      * @param mixed[] $payload
      */
-    protected function patchRequest(string $uri, array $payload): Response
+    protected function doPatchRequest(string $uri, array $payload): Response
     {
         return $this->jsonRequest('PATCH', $uri, $payload);
     }

--- a/tests/Functional/CreateSubcontractorTest.php
+++ b/tests/Functional/CreateSubcontractorTest.php
@@ -6,15 +6,15 @@ namespace App\Tests\Functional;
 
 use App\Entity\Subcontractor;
 use Doctrine\ORM\EntityManagerInterface;
-use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
+use Hautelook\AliceBundle\PhpUnit\ReloadDatabaseTrait;
 
 class CreateSubcontractorTest extends BaseWebTestCase
 {
-    use RefreshDatabaseTrait;
+    use ReloadDatabaseTrait;
 
     public function testSubcontractorCreatedWithName(): void
     {
-        $response = $this->postRequest('/subcontractors', ['name' => 'Concrete Bros.']);
+        $response = $this->doPostRequest('/subcontractors', ['name' => 'Concrete Bros.']);
 
         static::assertSame(201, $response->getStatusCode());
         $content = $this->decodeResponse($response);
@@ -34,7 +34,7 @@ class CreateSubcontractorTest extends BaseWebTestCase
 
     public function testCannotCreateWithoutName(): void
     {
-        $response = $this->postRequest('/subcontractors', []);
+        $response = $this->doPostRequest('/subcontractors', []);
 
         static::assertSame(400, $response->getStatusCode());
     }

--- a/tests/Functional/ListSubcontractorsTest.php
+++ b/tests/Functional/ListSubcontractorsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Subcontractor;
+use App\Utility\ArrayUtility;
+use Hautelook\AliceBundle\PhpUnit\ReloadDatabaseTrait;
+
+class ListSubcontractorsTest extends BaseWebTestCase
+{
+    use ReloadDatabaseTrait;
+
+    public function testListSubcontractors(): void
+    {
+        /** @var Subcontractor $knownSubbie */
+        $knownSubbie = static::$fixtures['subcontractor_known'];
+
+        $response = $this->doGetRequest('/subcontractors');
+
+        static::assertSame(200, $response->getStatusCode());
+        $content = $this->decodeResponse($response);
+
+        static::assertCount(13, $content);
+
+        $knownSubbieDetails = ArrayUtility::arrayFind(
+            $content,
+            fn(mixed $data) => is_array($data) && $data['id'] ?? null === $knownSubbie->getId(),
+        );
+
+        static::assertIsArray($knownSubbieDetails);
+        static::assertSame('Concrete Bros.', $knownSubbieDetails['name'] ?? -1);
+        static::assertSame(50_000_00, $knownSubbieDetails['price'] ?? -1);
+        static::assertSame(5_000_00, $knownSubbieDetails['discount'] ?? -1);
+        static::assertSame(500_00, $knownSubbieDetails['unletCost'] ?? -1);
+
+        static::assertArrayHasKey('adjustment', $knownSubbieDetails);
+        static::assertNull($knownSubbieDetails['adjustment']);
+    }
+}

--- a/tests/Functional/PatchSubcontractorTest.php
+++ b/tests/Functional/PatchSubcontractorTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace App\Tests\Functional;
 
 use App\Entity\Subcontractor;
-use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
+use Faker\Factory;
+use Hautelook\AliceBundle\PhpUnit\ReloadDatabaseTrait;
 
 class PatchSubcontractorTest extends BaseWebTestCase
 {
-    use RefreshDatabaseTrait;
+    use ReloadDatabaseTrait;
 
     public function testPatchSomeProperties(): void
     {
@@ -18,7 +19,7 @@ class PatchSubcontractorTest extends BaseWebTestCase
 
         $originalUnletCost = $subcontractor->getUnletCost();
 
-        $response = $this->patchRequest(
+        $response = $this->doPatchRequest(
             \sprintf('/subcontractors/%s', (string) $subcontractor->getId()),
             [
                 'name'        => 'Concrete Bros.',


### PR DESCRIPTION
I attempted this challenge myself and it took an entire hour, despite the fact that I designed the challenge and knew everything that needed implementing. I have decided to remove task three because:
1. It's largely the same as the patch subcontractor endpoint, so the candidate will just have to repeat themselves and waste time
2. We don't want to be taking up too much of the candidate's time
3. It allows us to showcase how we utilise response models and how core functions fit into the rest of the application

I also switched the task order so the core function comes first because it makes a better experience to build it and see how it fits into the list endpoint before attempting the patch endpoint.